### PR TITLE
Add process as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "jpeg-size": "0.0.1",
     "data-uri-to-u8": "~1.0.0",
     "exif-component": "0.0.2",
+    "process": "^0.11.2",
     "rotate-component": "~1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I got a missing dependency error when using fix-orientation with Browserify:

`Error: Cannot find module 'process' from '/Users/jamesshakespeare/Sites/roomzoom-js/node_modules/fix-orientation'`

So I added it to the `package.json`